### PR TITLE
bzip2/compress.c: Use upstream fix to silence warnings

### DIFF
--- a/bzip2/compress.c
+++ b/bzip2/compress.c
@@ -353,7 +353,7 @@ void sendMTFValues ( EState* s )
             Calculate the cost of this group as coded
             by each of the coding tables.
          --*/
-         for (t = 0; t < nGroups; t++) cost[t] = 0;
+         for (t = 0; t < BZ_N_GROUPS; t++) cost[t] = 0;
 
          if (nGroups == 6 && 50 == ge-gs+1) {
             /*--- fast track the common case ---*/


### PR DESCRIPTION
This silences these warnings.
```
bzip2/compress.c: In function ‘BZ2_compressBlock’:
bzip2/compress.c:391:54: warning: ‘cost[5]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                for (t = 0; t < nGroups; t++) cost[t] += s->len[t][icv];
                                                      ^
bzip2/compress.c:256:11: note: ‘cost[5]’ was declared here
    UInt16 cost[BZ_N_GROUPS];
           ^
bzip2/compress.c:401:25: warning: ‘cost[3]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             if (cost[t] < bc) { bc = cost[t]; bt = t; };
                         ^
bzip2/compress.c:256:11: note: ‘cost[3]’ was declared here
    UInt16 cost[BZ_N_GROUPS];
           ^
bzip2/compress.c:401:25: warning: ‘cost[2]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             if (cost[t] < bc) { bc = cost[t]; bt = t; };
                         ^
bzip2/compress.c:256:11: note: ‘cost[2]’ was declared here
    UInt16 cost[BZ_N_GROUPS];
           ^
```
Here is the upstream issue report.
https://rt.cpan.org/Public/Bug/Display.html?id=105647