### PR TITLE
Revert "Add support for git_version define"

### DIFF
--- a/gwlua/functions.c
+++ b/gwlua/functions.c
@@ -549,10 +549,8 @@ void register_image( lua_State* L, gwlua_t* state );
 void register_sound( lua_State* L, gwlua_t* state );
 void register_timer( lua_State* L, gwlua_t* state );
 
-#ifndef GIT_VERSION
 extern const char* gw_version;
 extern const char* gw_githash;
-#endif
 
 void register_functions( lua_State* L, gwlua_t* state )
 {
@@ -592,19 +590,11 @@ void register_functions( lua_State* L, gwlua_t* state )
   lua_pushlightuserdata( L, (void*)state );
   luaL_setfuncs( L, statics, 1 );
 
-#ifdef GIT_VERSION
-  lua_pushstring( L, GIT_VERSION );
-  lua_setfield( L, -2, "GW_VERSIONSTR" );
-  
-  lua_pushstring( L, GIT_VERSION );
-  lua_setfield( L, -2, "GW_GITHASH" );
-#else
   lua_pushstring( L, gw_version );
   lua_setfield( L, -2, "GW_VERSIONSTR" );
   
   lua_pushstring( L, gw_githash );
   lua_setfield( L, -2, "GW_GITHASH" );
-#endif
   
   // module
   

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -187,18 +187,12 @@ char* getenv( const char* name )
 
 /*---------------------------------------------------------------------------*/
 
-#ifndef GIT_VERSION
 extern const char* gw_version;
-#endif
 
 void retro_get_system_info( struct retro_system_info* info )
 {
   info->library_name = "Game & Watch";
-#ifdef GIT_VERSION
-  info->library_version = GIT_VERSION;
-#else
   info->library_version = gw_version;
-#endif
   info->need_fullpath = false;
   info->block_extract = false;
   info->valid_extensions = "mgw";
@@ -248,10 +242,8 @@ void retro_init()
     log_cb = log.log;
 }
 
-#ifndef GIT_VERSION
 extern const char* gw_gitstamp;
 extern const char* rl_gitstamp;
-#endif
 
 bool retro_load_game( const struct retro_game_info* info )
 {
@@ -267,9 +259,7 @@ bool retro_load_game( const struct retro_game_info* info )
   }
 
   
-#ifndef GIT_VERSION
   log_cb( RETRO_LOG_INFO, "\n%s\n%s", gw_gitstamp, rl_gitstamp );
-#endif
 
   int res = gwrom_init( &rom, (void*)info->data, info->size, GWROM_COPY_ALWAYS );
   


### PR DESCRIPTION
This reverts commit fd7349e73ce9022ff71184cd08bb641622fa29f0, which broke things on Android. (Should) fix https://github.com/libretro/gw-libretro/issues/52, which also has more info on the problem.